### PR TITLE
CDT-2115: Use queue in template when script hasn't finished loading

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://www.cludo.com"
 documentation: "https://cludohelp.force.com/helpcenter/s/"
 versions:
+  - sha: e0aa422fa1d9995e7110db109dbf087d8ef7016e,
+    changeNotes: Fix race condition for adding traits on page view/load
   - sha: cb22ec9a46dfd66fc1857fc9a49f7c42830e6264
     changeNotes: Initial release.


### PR DESCRIPTION
**Fixed Issue**
CDT-2115: GTM initialization race condition

### Issue Cause
If the initialization step has not completed by the time a trait trigger is processed, we will not persist the trait as expected.

### Code Changes
If we attempt to store the trait before the script fully loads, we will instead add the trait to a new `traitQueue` object. Then, on the successful script load, we add the stored values from the `traitQueue`.

### How to Reproduce Issue
In GTM, set up both the Cludo Search - Init and Cludo Search - Trait tags to fire on page view/load. The trait tag should fail, and the traits should not be visible in local storage.

### Testing Instructions
In GTM, use the new template to set up both the Cludo Search - Init and Cludo Search - Trait tags to fire on page view/load. The trait tag should succeed, and the trait should be stored once the init tag finishes loading the script.